### PR TITLE
Add unsubscribe instructions to notification email

### DIFF
--- a/resources/views/emails/new-comment.blade.php
+++ b/resources/views/emails/new-comment.blade.php
@@ -22,3 +22,5 @@
         </td>
     </tr>
 </table>
+
+<p>To stop receiving these notifications, <a href="https://giscus.co/">log in</a> and <a href="https://giscus.co/user/confirm-cancel">cancel your Giscus account</a>.</p>


### PR DESCRIPTION
Note that I would simply link to `https://giscus.co/user/confirm-cancel`. However, if not logged in, that redirects to `/login` which currently returns a 404. The only way to log in is apparently to first visit the home page and click the GitHub auth button. From there, a user can proceed to the cancellation confirmation page.

Starts addressing #31