### PR TITLE
Correct Readme to use yarn

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Looking for the code when it was using Cashier & Stripe? Check the [Archive-Cash
 
 ```bash
 composer install
-npm install
+yarn
 ```
 
 - Copy .env.example to .env:


### PR DESCRIPTION
I noticed the yarn.lock file after the PR was merged. Here is the correction.