### PR TITLE
Change mail from name and email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,8 @@ GITHUB_ID=
 GITHUB_SECRET=
 GITHUB_URL=http://host/auth/github/callback
 
-MAIL_FROM_EMAIL=matt@giscus.co
-MAIL_FROM_NAME="Matt Stauffer"
+MAIL_FROM_EMAIL=noreply@giscus.co
+MAIL_FROM_NAME="Giscus"
 
 BUGSNAG_API_KEY=
 SPARKPOST_API_KEY=


### PR DESCRIPTION
This PR will change the name and email address that are used to notify users of gist comments.

The new name/email is `Giscus <noreply@giscus.co>`

Note: this is a change to the example `.env` file, and will require a change in the production `.env` to deploy.