### PR TITLE
Update Authenticate middleware redirectTo

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -9,11 +9,12 @@ class Authenticate extends Middleware
     /**
      * Get the path the user should be redirected to when they are not authenticated.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
+     *
      * @return string
      */
     protected function redirectTo($request)
     {
-        return route('login');
+        return route('welcome');
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,6 @@
 <?php
 
-Route::get('/', ['middleware' => 'guest', 'uses' => 'WelcomeController@index']);
+Route::get('/', ['middleware' => 'guest', 'uses' => 'WelcomeController@index'])->name('welcome');
 
 Route::get('no-email', 'Auth\AuthController@noEmail');
 

--- a/tests/app/Controllers/AuthControllerTest.php
+++ b/tests/app/Controllers/AuthControllerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\App\Controllers;
+
+use Tests\BrowserKitTestCase;
+
+class AuthControllerTest extends BrowserKitTestCase
+{
+    public function testAuthRedirectToReturnsWelcomeRoute()
+    {
+        $response = $this->get('/home');
+
+        $response->assertRedirectedTo('/');
+        $response->assertRedirectedToRoute('welcome');
+    }
+}


### PR DESCRIPTION
# Overview 
This pull request fixes a [Bugsnag alert](https://app.bugsnag.com/markedstyle/giscus/errors/5bcda4ccd3d78a001974d5d6?event_id=5bcf2996003088d30fdc0001&i=sk&m=fx) that returned an `InvalidArgumentException`. 

## Solution

1. A route name was added to the existing guest `/` route.
1. Authenticate `redirectTo` now returns `route('welcome');` instead of `route('login');`
1. tests/app/Controllers/AuthController test added.