### PR TITLE
Fix overloaded queue worker

### DIFF
--- a/tests/app/Jobs/NotifyUserOfNewGistCommentsTest.php
+++ b/tests/app/Jobs/NotifyUserOfNewGistCommentsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\app\Jobs;
+
+use App\GistClient;
+use App\Jobs\NotifyUserOfNewGistComment;
+use App\Jobs\NotifyUserOfNewGistComments;
+use App\NotifiedComment;
+use App\User;
+use Github\Client;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Mail;
+use Mockery;
+use Tests\BrowserKitTestCase;
+
+class NotifyUserOfNewGistCommentsTest extends BrowserKitTestCase
+{
+    use DatabaseMigrations;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        Bus::fake();
+        Mail::fake();
+    }
+
+    public function testItDispatchesIndividualCommentNotificationJobForNewComment()
+    {
+        $user = factory(User::class)->create();
+
+        $comment = [
+            'id' => 2,
+            'updated_at' => $user->created_at->copy()->addDay(),
+            'body' => 'body',
+            'user' => [
+                'id' => 'test id, different from user id',
+            ],
+        ];
+
+        $gistClientMock = $this->createMock(GistClient::class);
+        $gistClientMock->method('all')->willReturn(collect([['id' => 'testId']]));
+
+        $githubClientMock = Mockery::mock(Client::class);
+        $githubClientMock->shouldReceive('api->comments->all')->andReturn([$comment]);
+
+        $NotifyUserOfNewGistComments = new NotifyUserOfNewGistComments($user);
+        $NotifyUserOfNewGistComments->handle($gistClientMock, $githubClientMock);
+
+        Bus::assertDispatched(NotifyUserOfNewGistComment::class);
+    }
+
+    public function testItDoesNotDispatchesIndividualCommentNotificationJobForAlreadyNotifiedComment()
+    {
+        $user = factory(User::class)->create();
+
+        $comment = [
+            'id' => 2,
+            'updated_at' => $user->created_at->copy()->addDay(),
+            'body' => 'body',
+            'user' => [
+                'id' => 'test id, different from user id',
+            ],
+        ];
+
+        NotifiedComment::create([
+            'github_id' => $comment['id'],
+            'github_updated_at' => $comment['updated_at'],
+        ]);
+
+        $gistClientMock = $this->createMock(GistClient::class);
+        $gistClientMock->method('all')->willReturn(collect([['id' => 'testId']]));
+
+        $githubClientMock = Mockery::mock(Client::class);
+        $githubClientMock->shouldReceive('api->comments->all')->andReturn([$comment]);
+
+        $NotifyUserOfNewGistComments = new NotifyUserOfNewGistComments($user);
+        $NotifyUserOfNewGistComments->handle($gistClientMock, $githubClientMock);
+
+        Bus::assertNotDispatched(NotifyUserOfNewGistComment::class);
+    }
+}


### PR DESCRIPTION
- Eager load the comments and diff them against gist comments to avoid dispatching jobs that are invalid.

*Problem:* It is a job taking too long. (No further logged details, but there are only 2 jobs, and one of those jobs just queues a bunch of the other job, the one that does the actual processing.).

*Solution(s):* We can

*A)* Increase the default timeout beyond the default `60` for the 2 jobs and “hope that fixes it”.
*B)* We can install Horizon and find out which of the 2 jobs is causing the timeout, which user is causing it, then implement an actual solution (read: optimization in the specific place).
*C)* We can fix the n+1 in the `NotifyUserOfNewGistComments.php` job, which is the most likely culprit and proceed until another fatal exception happens.

I recommend we do both *B)* and *C)*

This PR is *C)*.
https://github.com/tightenco/giscus/pull/52 is *B)*