### PR TITLE
Add plain text emails

### DIFF
--- a/app/Mail/ModifiedComment.php
+++ b/app/Mail/ModifiedComment.php
@@ -5,7 +5,6 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
 class ModifiedComment extends Mailable
 {
@@ -27,6 +26,7 @@ class ModifiedComment extends Mailable
     public function build()
     {
         return $this->view('emails.edit-comment')
+            ->text('emails.edit-comment_plain')
             ->subject('A comment on one of your gists was modified!');
     }
 }

--- a/app/Mail/NewComment.php
+++ b/app/Mail/NewComment.php
@@ -5,7 +5,6 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
 class NewComment extends Mailable
 {
@@ -27,6 +26,7 @@ class NewComment extends Mailable
     public function build()
     {
         return $this->view('emails.new-comment')
+            ->text('emails.new-comment_plain')
             ->subject('You have a new Gist Comment!');
     }
 }

--- a/resources/views/emails/edit-comment_plain.blade.php
+++ b/resources/views/emails/edit-comment_plain.blade.php
@@ -1,0 +1,15 @@
+<?php
+    $date = \Carbon\Carbon::createFromFormat('Y-m-d\TH:i:s\Z', $comment['updated_at']);
+?>
+
+A comment has been edited on a Gist,
+
+{{ $gist['description'] != '' ? $gist['description'] : '[No Gist title]' }}
+
+{{ $comment['user']['login'] }} commented {{ $date->diffForHumans() }}
+
+{!! $body !!}
+
+Want to stop receiving these notifications? Visit the link below.
+
+{{ $user->getUnsubscribeUrl() }}

--- a/resources/views/emails/new-comment_plain.blade.php
+++ b/resources/views/emails/new-comment_plain.blade.php
@@ -1,0 +1,13 @@
+<?php
+    $date = \Carbon\Carbon::createFromFormat('Y-m-d\TH:i:s\Z', $comment['updated_at']);
+?>
+
+You received a new comment on a Gist,
+
+{{ $comment['user']['login'] }} commented {{ $date->diffForHumans() }}
+
+{!! $body !!}
+
+Want to stop receiving these notifications? Visit the link below.
+
+{{ $user->getUnsubscribeUrl() }}


### PR DESCRIPTION
## Overview

**This PR closes #24 .** 

Mailtrap spam report returns `3.4` out of 5 without plain text emails. Adding them lowers the analysis down to `1.6`. 

### Before
<img width="1466" alt="screen shot 2018-11-15 at 11 10 53 am" src="https://user-images.githubusercontent.com/487612/48565700-2d3e6580-e8c7-11e8-9e55-f20c4e64cb34.png">

### After
<img width="1330" alt="screen shot 2018-11-15 at 11 22 45 am" src="https://user-images.githubusercontent.com/487612/48566437-c9b53780-e8c8-11e8-8355-e9498cf03e9e.png">
