### PR TITLE
Extend max queue notify time to 30m.

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -51,10 +51,11 @@ return [
     | will be fired. Every connection / queue combination may have its
     | own, unique threshold (in seconds) before this event is fired.
     |
+    | 1800 -> 30min
     */
 
     'waits' => [
-        'redis:default' => 60,
+        'redis:default' => 1800,
     ],
 
     /*


### PR DESCRIPTION
This is for the entire queue, and since new comments are all loaded at once by the cron, it makes sense to bump this up a bit (the rest of the time it is idle). 