### PR TITLE
Fix notifications sending for comments before user signed up for giscus.

### DIFF
--- a/app/Concerns/IdentifiesIfACommentNeedsNotification.php
+++ b/app/Concerns/IdentifiesIfACommentNeedsNotification.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Concerns;
+
+use App\NotifiedComment;
+use App\User;
+
+trait IdentifiesIfACommentNeedsNotification
+{
+    private function commentNeedsNotification($comment, User $user)
+    {
+        return ! (
+            $comment['updated_at'] < $user->created_at
+            || $comment['user']['id'] == $user->github_id
+            || NotifiedComment::where('github_id', $comment['id'])->count() > 0
+        );
+    }
+}


### PR DESCRIPTION
Problem: _Accidentally removed a check that prevented the app from notifying users of comments on their gists that were made before their sign up to Giscus._

Solution: Extracted and added checks to the aggregating job (the one that creates the jobs that actually send the notification), as well as the notification job + tests for both.