### PR TITLE
Change timeout and retry_after for horizon/redis jobs

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -108,6 +108,7 @@ return [
                 'balance' => 'simple',
                 'processes' => 10,
                 'tries' => 3,
+                'timeout' => 180,
             ],
         ],
 
@@ -118,6 +119,7 @@ return [
                 'balance' => 'simple',
                 'processes' => 3,
                 'tries' => 3,
+                'timeout' => 180,
             ],
         ],
     ],

--- a/config/queue.php
+++ b/config/queue.php
@@ -61,7 +61,7 @@ return [
             'driver' => 'redis',
             'connection' => 'default',
             'queue' => 'default',
-            'retry_after' => 90,
+            'retry_after' => 300,
             'block_for' => null,
         ],
 


### PR DESCRIPTION
This PR increases the `timeout` and `retry_after` config values to allow for longer running jobs.

The new job timeout (in `horizon.php`) is 180 seconds.

In `queue.php`, the new `retry_after` for the redis connection is 300 seconds.

The `retry_after` value should always be larger than the `timeout` value so jobs don't run twice. This should also allow for temporary GitHub service issues to resolve before trying a failing job again.