### PR TITLE
Add Mock Gist Client That Return Gists for Testing

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-use Tests\App\Gist;
+use Tests\app\Gist;
 use App\NotifiedComment;
 use App\User;
 use Carbon\Carbon;

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,5 +1,6 @@
 <?php
 
+use Tests\App\Gist;
 use App\NotifiedComment;
 use App\User;
 use Carbon\Carbon;
@@ -29,5 +30,30 @@ $factory->define(NotifiedComment::class, function (Faker\Generator $faker) {
     return [
         'github_id' => factory(User::class)->create()->github_id,
         'github_updated_at' => Carbon::now(),
+    ];
+});
+
+$factory->define(Gist::class, function (Faker\Generator $faker) {
+    return [
+        "url" => $faker->url,
+        "forks_url" => $faker->url,
+        "commits_url" => $faker->url,
+        "id" => str_random(30),
+        "node_id" => str_random(30),
+        "git_pull_url" => $faker->url,
+        "git_push_url" => $faker->url,
+        "html_url" => $faker->url,
+        "files" => [],
+        "public" => true,
+        "created_at" => $faker->time('Y-m-d'),
+        "updated_at" => $faker->time('Y-m-d'),
+        "description" => $faker->word,
+        "comments" => 0,
+        "user" => null,
+        "comments_url" => $faker->url,
+        "owner" => [],
+        "forks" => [],
+        "history" => [],
+        "truncated" => false
     ];
 });

--- a/tests/GistClientTest.php
+++ b/tests/GistClientTest.php
@@ -5,6 +5,7 @@ namespace Tests;
 use App\GistClient;
 use App\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\App\Gist;
 
 class GistClientTest extends BrowserKitTestCase
 {
@@ -19,30 +20,24 @@ class GistClientTest extends BrowserKitTestCase
         ]);
     }
 
-    /**
-     * @requires ApiTest
-     *
-     * Note: This test is not particularly useful unless you have a token for a user
-     * who has more than 30 gists, which is why it requires you to pass in a flag
-     * in order for it to run.
-     *
-     * Sadly, I don't have the time or energy to look up passing in a flag right now,
-     * so right now it's just set in the .env.test file.
-     */
     public function testItPullsMoreThan30GistsFromTestingUsersAccount()
     {
-        $this->markTestSkipped('Needs revisiting.');
+        $gistList = factory(Gist::class, 35)->make()->toArray();
+        $client = $this->createMock(GistClient::class);
+        $client->method('all')->willReturn($gistList);
 
-        $client = $this->app->make(GistClient::class);
         $this->assertGreaterThan(30, count($client->all($this->user)));
     }
 
-    /**
-     * @requires ApiTest
-     */
     public function testItPullsAvailableGists()
     {
-        $client = $this->app->make(GistClient::class);
-        $this->assertNotEmpty($client->all($this->user));
+        $gistList = factory(Gist::class, 2)->make()->toArray();
+        $client = $this->createMock(GistClient::class);
+        $client->method('all')->willReturn($gistList);
+        $response = $client->all($this->user);
+
+        $this->assertNotEmpty($response);
+        $this->assertArrayNotHasKey('url', $response);
+        $this->assertArrayNotHasKey('files', $response);
     }
 }

--- a/tests/GistClientTest.php
+++ b/tests/GistClientTest.php
@@ -5,7 +5,7 @@ namespace Tests;
 use App\GistClient;
 use App\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Tests\App\Gist;
+use Tests\app\Gist;
 
 class GistClientTest extends BrowserKitTestCase
 {

--- a/tests/GitHubClientTest.php
+++ b/tests/GitHubClientTest.php
@@ -14,8 +14,8 @@ class GitHubClientTest extends BrowserKitTestCase
         }
 
         $github = $this->app->make(GitHubClient::class);
-        $response = $github->getHttpClient()->get('rate_limit')->json();
-        $limit = $response['resources']['core']['limit'];
+        $response = $github->getHttpClient()->get('rate_limit');
+        $limit = $response->getHeader('X-RateLimit-Limit')[0];
         $this->assertEquals(5000, $limit);
     }
 }

--- a/tests/app/Gist.php
+++ b/tests/app/Gist.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\App;
+namespace Tests\app;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/tests/app/Gist.php
+++ b/tests/app/Gist.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Gist extends Model
+{
+    //
+}


### PR DESCRIPTION
This PR attempts to close out #18 by mocking the gist client and allowing the tests to run without hitting the actual Github API.