### PR TITLE
Remove login button and consent checkbox (closes #71)

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -11,18 +11,6 @@
 
             <p>Receive up-to-the-hour notifications on comments on your Gists. No work on your part, free because
                 Tighten {{--and DigitalOcean love--}} loves you, cancel any time.</p>
-            <p>
-                <form method="post" action="/auth/github">
-                    {{ csrf_field() }}
-                    <button type="submit" class="btn btn-default">
-                        <i class="fa fa-github"></i> Sign Up / Log In With GitHub
-                    </button>
-                    <label class="checkbox-label">
-                        <input name="allow-private" type="checkbox" checked>
-                        Allow us to access your private Gists (if signing up)
-                    </label>
-                </form>
-            </p>
             <div>
                 <h4 class="sponsors-label">Sponsored by</h4>
                 <ul class="list-inline">


### PR DESCRIPTION
Removal of the Github login button and subsequent checkbox from the landing page. 